### PR TITLE
Add GPU-based hover info

### DIFF
--- a/src/components/PlanetCanvas.vue
+++ b/src/components/PlanetCanvas.vue
@@ -4,9 +4,11 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
+import * as THREE from 'three'
 import { Planet } from '@/core/Planet'
 import { usePlanetStore } from '@/stores/planet'
 import { DataTargetRenderer } from '@/core/DataTargetRenderer'
+import { BiomeMap } from '@/core/BiomeMap'
 
 const canvasRef = ref<HTMLCanvasElement | null>(null)
 
@@ -17,6 +19,9 @@ onMounted(() => {
   const planet = new Planet(canvas)
   const renderer = planet.getRenderer()
   const dataTarget = new DataTargetRenderer(canvas.width, canvas.height, renderer, planet.getMesh(), planet.getCamera())
+  const raycaster = new THREE.Raycaster()
+  const mouse = new THREE.Vector2()
+  const biomeMap = new BiomeMap()
 
   planet.animate()
 
@@ -25,14 +30,26 @@ onMounted(() => {
     const x = Math.floor(e.clientX - rect.left)
     const y = Math.floor(e.clientY - rect.top)
 
+    // Determine latitude/longitude via raycasting
+    mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1
+    mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1
+    raycaster.setFromCamera(mouse, planet.getCamera())
+    const hits = raycaster.intersectObject(planet.getMesh())
+    if (hits.length === 0) return
+    const point = hits[0].point.clone().normalize()
+    const lat = Math.asin(point.y) / Math.PI
+    const lon = Math.atan2(point.z, point.x) / (2 * Math.PI)
+
+    // Read encoded climate data from the GPU
     dataTarget.render()
     const pixel = dataTarget.readPixel(x, y)
     const decoded = dataTarget.decodePixel(pixel)
+    const biome = biomeMap.get(decoded.temperature, decoded.pressure, decoded.elevation)
 
     usePlanetStore().setHover({
-      lat: 0, // placeholder, will replace with raycast logic later
-      lon: 0,
-      biome: 'Unknown',
+      lat,
+      lon,
+      biome,
       ...decoded
     })
   })

--- a/src/core/BiomeMap.ts
+++ b/src/core/BiomeMap.ts
@@ -1,15 +1,16 @@
-import { ClimateModel } from "./ClimateModel"
-
 export class BiomeMap {
-	constructor(private climate: ClimateModel) {}
-
-	get(lat: number, elevation: number, temperature: number): string {
-		if (temperature < -20) return 'Frozen Wastes'
-		if (temperature < -5) return 'Tundra'
-		if (temperature < 10) return 'Taiga'
-		if (temperature < 25) return 'Forest'
-		if (temperature < 35) return 'Savanna'
-		if (temperature < 60) return 'Desert'
-		return 'Burnt'
-	}
+        /**
+         * Classify a biome based on temperature, pressure and elevation.
+         * This mirrors the logic used in the fragment shader so that
+         * the textual biome matches the colours rendered on the planet.
+         */
+        get(temperature: number, pressure: number, elevation: number): string {
+                if (elevation < 0.1) return 'Ocean'
+                if (temperature < -15) return 'Ice cap'
+                if (temperature < 0) return 'Tundra'
+                if (pressure < 0.4) return 'Highlands'
+                if (temperature < 20) return 'Forest'
+                if (temperature < 35) return 'Savanna'
+                return 'Burnt desert'
+        }
 }

--- a/src/core/PlanetGenerator.ts
+++ b/src/core/PlanetGenerator.ts
@@ -7,11 +7,11 @@ export class PlanetGenerator {
 	biomeMap: BiomeMap
 	climateModel: ClimateModel
 
-	constructor(seed = Math.random()) {
-		this.heightMap = new HeightMap(seed)
-		this.climateModel = new ClimateModel()
-		this.biomeMap = new BiomeMap(this.climateModel)
-	}
+        constructor(seed = Math.random()) {
+                this.heightMap = new HeightMap(seed)
+                this.climateModel = new ClimateModel()
+                this.biomeMap = new BiomeMap()
+        }
 
 	sample(lat: number, lon: number): {
 		elevation: number
@@ -19,10 +19,10 @@ export class PlanetGenerator {
 		pressure: number
 		biome: string
 	} {
-		const elevation = this.heightMap.get(lat, lon)
-		const temperature = this.climateModel.getTemperature(lat, elevation)
-		const pressure = this.climateModel.getPressure(elevation)
-		const biome = this.biomeMap.get(lat, elevation, temperature)
-		return { elevation, temperature, pressure, biome }
+                const elevation = this.heightMap.get(lat, lon)
+                const temperature = this.climateModel.getTemperature(lat, elevation)
+                const pressure = this.climateModel.getPressure(elevation)
+                const biome = this.biomeMap.get(temperature, pressure, elevation)
+                return { elevation, temperature, pressure, biome }
 	}
 }


### PR DESCRIPTION
## Summary
- update biome classification to match shader
- adjust generator to use new biome map signature
- read hover data via raycasting and GPU readback

## Testing
- `npx vue-tsc --noEmit`
- `npx vite build`

------
https://chatgpt.com/codex/tasks/task_e_685d6e0948188333bba2d5b44de519d9