### PR TITLE
Add planet types and hover line

### DIFF
--- a/src/components/PlanetCanvas.vue
+++ b/src/components/PlanetCanvas.vue
@@ -4,9 +4,11 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
+import * as THREE from 'three'
 import { Planet } from '@/core/Planet'
 import { usePlanetStore } from '@/stores/planet'
 import { DataTargetRenderer } from '@/core/DataTargetRenderer'
+import type { PlanetType } from '@/core/planetPresets'
 
 const canvasRef = ref<HTMLCanvasElement | null>(null)
 
@@ -14,25 +16,52 @@ onMounted(() => {
   if (!canvasRef.value) return
 
   const canvas = canvasRef.value
-  const planet = new Planet(canvas)
+  const types: PlanetType[] = ['earth', 'ice', 'burnt', 'moon', 'gas']
+  const type = types[Math.floor(Math.random() * types.length)]
+  const planet = new Planet(canvas, type)
   const renderer = planet.getRenderer()
-  const dataTarget = new DataTargetRenderer(canvas.width, canvas.height, renderer, planet.getMesh(), planet.getCamera())
+  const dataTarget = new DataTargetRenderer(canvas.width, canvas.height, renderer, planet.getMesh(), planet.getCamera(), planet.getEquatorTemp())
+  const raycaster = new THREE.Raycaster()
+  const mouse = new THREE.Vector2()
+  const biomeMap = planet.getGenerator().biomeMap
 
   planet.animate()
+
+  let rotating = true
+  window.addEventListener('keydown', (e) => {
+    if (e.code === 'Space') {
+      rotating = !rotating
+      planet.setAutoRotate(rotating)
+    }
+  })
 
   canvas.addEventListener('mousemove', (e) => {
     const rect = canvas.getBoundingClientRect()
     const x = Math.floor(e.clientX - rect.left)
     const y = Math.floor(e.clientY - rect.top)
 
+    // Determine latitude/longitude via raycasting
+    mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1
+    mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1
+    raycaster.setFromCamera(mouse, planet.getCamera())
+    const hits = raycaster.intersectObject(planet.getMesh())
+    if (hits.length === 0) return
+    const hitPoint = hits[0].point.clone()
+    planet.updateLine(hitPoint)
+    const norm = hitPoint.clone().normalize()
+    const lat = Math.asin(norm.y) / Math.PI
+    const lon = Math.atan2(norm.z, norm.x) / (2 * Math.PI)
+
+    // Read encoded climate data from the GPU
     dataTarget.render()
     const pixel = dataTarget.readPixel(x, y)
     const decoded = dataTarget.decodePixel(pixel)
+    const biome = biomeMap.get(decoded.temperature, decoded.pressure, decoded.elevation)
 
     usePlanetStore().setHover({
-      lat: 0, // placeholder, will replace with raycast logic later
-      lon: 0,
-      biome: 'Unknown',
+      lat,
+      lon,
+      biome,
       ...decoded
     })
   })

--- a/src/core/BiomeMap.ts
+++ b/src/core/BiomeMap.ts
@@ -1,15 +1,17 @@
-import { ClimateModel } from "./ClimateModel"
-
 export class BiomeMap {
-	constructor(private climate: ClimateModel) {}
-
-	get(lat: number, elevation: number, temperature: number): string {
-		if (temperature < -20) return 'Frozen Wastes'
-		if (temperature < -5) return 'Tundra'
-		if (temperature < 10) return 'Taiga'
-		if (temperature < 25) return 'Forest'
-		if (temperature < 35) return 'Savanna'
-		if (temperature < 60) return 'Desert'
-		return 'Burnt'
-	}
+        constructor(private seaLevel: number) {}
+        /**
+         * Classify a biome based on temperature, pressure and elevation.
+         * This mirrors the logic used in the fragment shader so that
+         * the textual biome matches the colours rendered on the planet.
+         */
+        get(temperature: number, pressure: number, elevation: number): string {
+                if (elevation < this.seaLevel) return 'Ocean'
+                if (temperature < -15) return 'Ice cap'
+                if (temperature < 0) return 'Tundra'
+                if (pressure < 0.4) return 'Highlands'
+                if (temperature < 20) return 'Forest'
+                if (temperature < 35) return 'Savanna'
+                return 'Burnt desert'
+        }
 }

--- a/src/core/DataMaterial.ts
+++ b/src/core/DataMaterial.ts
@@ -1,23 +1,25 @@
 import * as THREE from 'three'
 
 export class DataMaterial extends THREE.ShaderMaterial {
-	constructor() {
-		super({
-			uniforms: {
-				elevationScale: { value: 0.2 },
-				obliquity: { value: 0.41 },
-				seed: { value: Math.random() * 1000 }
-			},
-			vertexShader,
-			fragmentShader,
-		})
-	}
+        constructor(equatorTemp: number) {
+                super({
+                        uniforms: {
+                                elevationScale: { value: 0.2 },
+                                obliquity: { value: 0.41 },
+                                seed: { value: Math.random() * 1000 },
+                                equatorTemp: { value: equatorTemp }
+                        },
+                        vertexShader,
+                        fragmentShader,
+                })
+        }
 }
 
 const vertexShader = /* glsl */`
 uniform float elevationScale;
 uniform float obliquity;
 uniform float seed;
+uniform float equatorTemp;
 
 varying float vElevation;
 varying float vLatitude;
@@ -89,7 +91,7 @@ varying float vLatitude;
 
 void main() {
   float lat = clamp(vLatitude, -1.0, 1.0);
-  float baseTemp = 60.0 * (1.0 - abs(lat));
+  float baseTemp = equatorTemp * (1.0 - abs(lat));
   float temp = baseTemp - vElevation * 65.0;
   float pressure = exp(-vElevation * 6.0);
 

--- a/src/core/DataTargetRenderer.ts
+++ b/src/core/DataTargetRenderer.ts
@@ -5,16 +5,17 @@ export class DataTargetRenderer {
 	public renderTarget: THREE.WebGLRenderTarget
 	public material: DataMaterial
 
-	constructor(
-		private width: number,
-		private height: number,
-		private renderer: THREE.WebGLRenderer,
-		private mesh: THREE.Mesh,
-		private camera: THREE.PerspectiveCamera
-	) {
-		this.renderTarget = new THREE.WebGLRenderTarget(width, height)
-		this.material = new DataMaterial()
-	}
+        constructor(
+                private width: number,
+                private height: number,
+                private renderer: THREE.WebGLRenderer,
+                private mesh: THREE.Mesh,
+                private camera: THREE.PerspectiveCamera,
+                equatorTemp: number
+        ) {
+                this.renderTarget = new THREE.WebGLRenderTarget(width, height)
+                this.material = new DataMaterial(equatorTemp)
+        }
 
 	render() {
 		const originalMaterial = this.mesh.material

--- a/src/core/Planet.ts
+++ b/src/core/Planet.ts
@@ -1,39 +1,60 @@
 import * as THREE from 'three'
 import { PlanetGenerator } from './PlanetGenerator'
-import { PlanetMaterial } from './PlanetMaterial'
+import { PlanetMaterial, PlanetMaterialOptions } from './PlanetMaterial'
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
+import { PlanetType, PlanetPreset, PlanetPresets } from './planetPresets'
 
 export class Planet {
-	private scene: THREE.Scene
-	private camera: THREE.PerspectiveCamera
-	private renderer: THREE.WebGLRenderer
-	private mesh: THREE.Mesh
-	private animationId = 0
-	private generator: PlanetGenerator
+        private scene: THREE.Scene
+        private camera: THREE.PerspectiveCamera
+        private renderer: THREE.WebGLRenderer
+        private mesh: THREE.Mesh
+        private animationId = 0
+        private generator: PlanetGenerator
+        private controls: OrbitControls
+        private line: THREE.Line
+        private autoRotate = true
+        private preset: PlanetPreset
 
-	constructor(canvas: HTMLCanvasElement) {
-		this.scene = new THREE.Scene()
-		this.camera = new THREE.PerspectiveCamera(45, canvas.clientWidth / canvas.clientHeight, 0.1, 1000)
-		this.camera.position.z = 3
+        constructor(canvas: HTMLCanvasElement, type: PlanetType = 'earth') {
+                this.scene = new THREE.Scene()
+                this.camera = new THREE.PerspectiveCamera(45, canvas.clientWidth / canvas.clientHeight, 0.1, 1000)
+                this.camera.position.z = 3
 
-		this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true })
-		this.renderer.setSize(canvas.clientWidth, canvas.clientHeight)
+                this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true })
+                this.renderer.setSize(canvas.clientWidth, canvas.clientHeight)
 
-		this.generator = new PlanetGenerator()
-		this.mesh = this.createPlanetMesh()
+                this.preset = PlanetPresets[type]
+                this.generator = new PlanetGenerator(Math.random(), type)
+                this.mesh = this.createPlanetMesh({ seaLevel: this.preset.seaLevel, equatorTemp: this.preset.equatorTemp })
+
+                this.controls = new OrbitControls(this.camera, this.renderer.domElement)
+                this.controls.enableDamping = true
+                this.controls.enablePan = false
+                this.controls.mouseButtons = {
+                        LEFT: THREE.MOUSE.PAN,
+                        MIDDLE: THREE.MOUSE.ROTATE,
+                        RIGHT: THREE.MOUSE.DOLLY
+                }
+
+                const lineGeo = new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(), new THREE.Vector3()])
+                const lineMat = new THREE.LineBasicMaterial({ color: 0xffffff })
+                this.line = new THREE.Line(lineGeo, lineMat)
+                this.scene.add(this.line)
 
 		this.scene.add(this.mesh)
 		this.scene.add(new THREE.AmbientLight(0xffffff, 1))
 	}
 
-	private createPlanetMesh(): THREE.Mesh {
-		const radius = 1
-		const subd = 16
-		const geometry = new THREE.IcosahedronGeometry(radius, subd)
-		geometry.computeVertexNormals()
+        private createPlanetMesh(options: PlanetMaterialOptions): THREE.Mesh {
+                const radius = 1
+                const subd = 16
+                const geometry = new THREE.IcosahedronGeometry(radius, subd)
+                geometry.computeVertexNormals()
 
-		const material = new PlanetMaterial()
-		return new THREE.Mesh(geometry, material)
-	}
+                const material = new PlanetMaterial(options)
+                return new THREE.Mesh(geometry, material)
+        }
 
 	private getBiomeColor(biome: string): THREE.Color {
 		switch (biome) {
@@ -47,20 +68,33 @@ export class Planet {
 		}
 	}
 
-	animate() {
-		(this.mesh.material as PlanetMaterial).update(performance.now() / 1000)
-		this.mesh.rotation.y += 0.002
-		this.renderer.render(this.scene, this.camera)
-		this.animationId = requestAnimationFrame(() => this.animate())
-	}
+        animate() {
+                (this.mesh.material as PlanetMaterial).update(performance.now() / 1000)
+                if (this.autoRotate) this.mesh.rotation.y += 0.002
+                this.controls.update()
+                this.renderer.render(this.scene, this.camera)
+                this.animationId = requestAnimationFrame(() => this.animate())
+        }
 
-	dispose() {
-		cancelAnimationFrame(this.animationId)
-		this.renderer.dispose()
-	}
+        dispose() {
+                cancelAnimationFrame(this.animationId)
+                this.renderer.dispose()
+        }
 
-	getCamera() { return this.camera }
-	getMesh() { return this.mesh }
-	getGenerator() { return this.generator }
-	getRenderer() { return this.renderer }
+        setAutoRotate(value: boolean) {
+                this.autoRotate = value
+        }
+
+        updateLine(target: THREE.Vector3) {
+                const pos = this.line.geometry.getAttribute('position') as THREE.BufferAttribute
+                pos.setXYZ(0, this.camera.position.x, this.camera.position.y, this.camera.position.z)
+                pos.setXYZ(1, target.x, target.y, target.z)
+                pos.needsUpdate = true
+        }
+
+        getCamera() { return this.camera }
+        getMesh() { return this.mesh }
+        getGenerator() { return this.generator }
+        getEquatorTemp() { return this.preset.equatorTemp }
+        getRenderer() { return this.renderer }
 }

--- a/src/core/PlanetGenerator.ts
+++ b/src/core/PlanetGenerator.ts
@@ -1,17 +1,19 @@
 import { HeightMap } from './HeightMap'
 import { BiomeMap } from './BiomeMap'
 import { ClimateModel } from './ClimateModel'
+import { PlanetType, PlanetPresets } from './planetPresets'
 
 export class PlanetGenerator {
-	heightMap: HeightMap
-	biomeMap: BiomeMap
-	climateModel: ClimateModel
+        heightMap: HeightMap
+        biomeMap: BiomeMap
+        climateModel: ClimateModel
 
-	constructor(seed = Math.random()) {
-		this.heightMap = new HeightMap(seed)
-		this.climateModel = new ClimateModel()
-		this.biomeMap = new BiomeMap(this.climateModel)
-	}
+        constructor(seed = Math.random(), type: PlanetType = 'earth') {
+                const preset = PlanetPresets[type]
+                this.heightMap = new HeightMap(seed)
+                this.climateModel = new ClimateModel(preset.equatorTemp)
+                this.biomeMap = new BiomeMap(preset.seaLevel)
+        }
 
 	sample(lat: number, lon: number): {
 		elevation: number
@@ -19,10 +21,10 @@ export class PlanetGenerator {
 		pressure: number
 		biome: string
 	} {
-		const elevation = this.heightMap.get(lat, lon)
-		const temperature = this.climateModel.getTemperature(lat, elevation)
-		const pressure = this.climateModel.getPressure(elevation)
-		const biome = this.biomeMap.get(lat, elevation, temperature)
-		return { elevation, temperature, pressure, biome }
+                const elevation = this.heightMap.get(lat, lon)
+                const temperature = this.climateModel.getTemperature(lat, elevation)
+                const pressure = this.climateModel.getPressure(elevation)
+                const biome = this.biomeMap.get(temperature, pressure, elevation)
+                return { elevation, temperature, pressure, biome }
 	}
 }

--- a/src/core/planetPresets.ts
+++ b/src/core/planetPresets.ts
@@ -1,0 +1,14 @@
+export type PlanetType = 'earth' | 'ice' | 'burnt' | 'moon' | 'gas'
+
+export interface PlanetPreset {
+  seaLevel: number
+  equatorTemp: number
+}
+
+export const PlanetPresets: Record<PlanetType, PlanetPreset> = {
+  earth: { seaLevel: 0.12, equatorTemp: 30 },
+  ice: { seaLevel: 0.15, equatorTemp: 0 },
+  burnt: { seaLevel: 0.03, equatorTemp: 60 },
+  moon: { seaLevel: 0.0, equatorTemp: 5 },
+  gas: { seaLevel: 0.8, equatorTemp: 120 }
+}


### PR DESCRIPTION
## Summary
- create planet presets for varying climate
- pass temperature presets through shaders
- render a line to the hovered location
- allow pausing auto-rotation with space key
- expose orbit controls with middle mouse button

## Testing
- `npx vue-tsc --noEmit`
- `npx vite build`


------
https://chatgpt.com/codex/tasks/task_e_685d6e0948188333bba2d5b44de519d9