### PR TITLE
Fix hover info reactivity and flatten oceans

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@
 
 		<div class="absolute top-4 left-4 z-10">
 			<h1 class="text-2xl font-bold mb-4">Procedural Planet Generator</h1>
-			<InfoPanel biome="Ocean" :temperature="15.2" :pressure="101.3" />
+                <InfoPanel />
 		</div>
 	</div>
 </template>

--- a/src/components/InfoPanel.vue
+++ b/src/components/InfoPanel.vue
@@ -14,5 +14,8 @@
 
 <script setup lang="ts">
 import { usePlanetStore } from '@/stores/planet'
-const hover = usePlanetStore().hover
+import { storeToRefs } from 'pinia'
+
+const store = usePlanetStore()
+const { hover } = storeToRefs(store)
 </script>

--- a/src/components/PlanetCanvas.vue
+++ b/src/components/PlanetCanvas.vue
@@ -21,7 +21,15 @@ onMounted(() => {
   const type = types[Math.floor(Math.random() * types.length)]
   const planet = new Planet(canvas, type)
   const renderer = planet.getRenderer()
-  const dataTarget = new DataTargetRenderer(canvas.width, canvas.height, renderer, planet.getMesh(), planet.getCamera(), planet.getEquatorTemp())
+  const dataTarget = new DataTargetRenderer(
+    canvas.width,
+    canvas.height,
+    renderer,
+    planet.getMesh(),
+    planet.getCamera(),
+    planet.getEquatorTemp(),
+    planet.getSeaLevel()
+  )
   const raycaster = new THREE.Raycaster()
   const mouse = new THREE.Vector2()
   const biomeMap = planet.getGenerator().biomeMap

--- a/src/components/PlanetCanvas.vue
+++ b/src/components/PlanetCanvas.vue
@@ -29,8 +29,8 @@ onMounted(() => {
   const planet = new Planet(canvas, type)
   const renderer = planet.getRenderer()
   const dataTarget = new DataTargetRenderer(
-    canvas.width,
-    canvas.height,
+    canvas.clientWidth,
+    canvas.clientHeight,
     renderer,
     planet.getMesh(),
     planet.getCamera(),
@@ -68,11 +68,15 @@ onMounted(() => {
     raycaster.setFromCamera(mouse, planet.getCamera())
     const hits = raycaster.intersectObject(planet.getMesh())
     if (hits.length === 0) return
+
     const hitPoint = hits[0].point.clone()
     planet.updateLine(hitPoint)
-    const norm = hitPoint.clone().normalize()
-    const lat = Math.asin(norm.y) / Math.PI
-    const lon = Math.atan2(norm.z, norm.x) / (2 * Math.PI)
+
+    // Convert hit point to the planet's local space so that rotation
+    // doesn't affect latitude/longitude calculations
+    const local = planet.getMesh().worldToLocal(hitPoint.clone()).normalize()
+    const lat = Math.asin(local.y) / Math.PI
+    const lon = Math.atan2(local.z, local.x) / (2 * Math.PI)
 
     // Read encoded climate data from the GPU
     dataTarget.render()

--- a/src/components/PlanetCanvas.vue
+++ b/src/components/PlanetCanvas.vue
@@ -29,8 +29,8 @@ onMounted(() => {
   const planet = new Planet(canvas, type)
   const renderer = planet.getRenderer()
   const dataTarget = new DataTargetRenderer(
-    canvas.clientWidth,
-    canvas.clientHeight,
+    canvas.width,
+    canvas.height,
     renderer,
     planet.getMesh(),
     planet.getCamera(),
@@ -56,6 +56,9 @@ onMounted(() => {
     const rect = canvas.getBoundingClientRect()
     const x = Math.floor(e.clientX - rect.left)
     const y = Math.floor(e.clientY - rect.top)
+    const pxRatio = renderer.getPixelRatio()
+    const pixelX = Math.floor(x * pxRatio)
+    const pixelY = Math.floor(y * pxRatio)
 
     if (crosshairRef.value) {
       crosshairRef.value.style.left = `${x}px`
@@ -80,7 +83,7 @@ onMounted(() => {
 
     // Read encoded climate data from the GPU
     dataTarget.render()
-    const pixel = dataTarget.readPixel(x, y)
+    const pixel = dataTarget.readPixel(pixelX, pixelY)
     const decoded = dataTarget.decodePixel(pixel)
     const biome = biomeMap.get(decoded.temperature, decoded.pressure, decoded.elevation)
 

--- a/src/components/PlanetCanvas.vue
+++ b/src/components/PlanetCanvas.vue
@@ -1,5 +1,11 @@
 <template>
-  <canvas ref="canvasRef" class="w-screen h-screen block"></canvas>
+  <div class="relative w-screen h-screen">
+    <canvas ref="canvasRef" class="w-full h-full block"></canvas>
+    <div ref="crosshairRef" class="pointer-events-none absolute crosshair">
+      <div class="vertical"></div>
+      <div class="horizontal"></div>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -12,6 +18,7 @@ import type { PlanetType } from '@/core/planetPresets'
 import { BiomeMap } from '@/core/BiomeMap'
 
 const canvasRef = ref<HTMLCanvasElement | null>(null)
+const crosshairRef = ref<HTMLDivElement | null>(null)
 
 onMounted(() => {
   if (!canvasRef.value) return
@@ -28,7 +35,8 @@ onMounted(() => {
     planet.getMesh(),
     planet.getCamera(),
     planet.getEquatorTemp(),
-    planet.getSeaLevel()
+    planet.getSeaLevel(),
+    planet.getSeed()
   )
   const raycaster = new THREE.Raycaster()
   const mouse = new THREE.Vector2()
@@ -48,6 +56,11 @@ onMounted(() => {
     const rect = canvas.getBoundingClientRect()
     const x = Math.floor(e.clientX - rect.left)
     const y = Math.floor(e.clientY - rect.top)
+
+    if (crosshairRef.value) {
+      crosshairRef.value.style.left = `${x}px`
+      crosshairRef.value.style.top = `${y}px`
+    }
 
     // Determine latitude/longitude via raycasting
     mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1
@@ -80,5 +93,28 @@ onMounted(() => {
 <style scoped>
 canvas {
   display: block;
+}
+.crosshair {
+  width: 12px;
+  height: 12px;
+  transform: translate(-50%, -50%);
+}
+.crosshair .vertical {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  width: 2px;
+  height: 100%;
+  background: red;
+  transform: translateX(-50%);
+}
+.crosshair .horizontal {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  height: 2px;
+  width: 100%;
+  background: red;
+  transform: translateY(-50%);
 }
 </style>

--- a/src/core/DataMaterial.ts
+++ b/src/core/DataMaterial.ts
@@ -1,12 +1,12 @@
 import * as THREE from 'three'
 
 export class DataMaterial extends THREE.ShaderMaterial {
-        constructor(equatorTemp: number, seaLevel: number) {
+        constructor(equatorTemp: number, seaLevel: number, seed: number) {
                 super({
                         uniforms: {
                                 elevationScale: { value: 0.2 },
                                 obliquity: { value: 0.41 },
-                                seed: { value: Math.random() * 1000 },
+                                seed: { value: seed },
                                 equatorTemp: { value: equatorTemp },
                                 seaLevel: { value: seaLevel }
                         },

--- a/src/core/DataMaterial.ts
+++ b/src/core/DataMaterial.ts
@@ -88,6 +88,8 @@ void main() {
 `;
 
 const fragmentShader = /* glsl */`
+uniform float equatorTemp;
+uniform float seaLevel;
 varying float vElevation;
 varying float vLatitude;
 

--- a/src/core/DataMaterial.ts
+++ b/src/core/DataMaterial.ts
@@ -1,13 +1,14 @@
 import * as THREE from 'three'
 
 export class DataMaterial extends THREE.ShaderMaterial {
-        constructor(equatorTemp: number) {
+        constructor(equatorTemp: number, seaLevel: number) {
                 super({
                         uniforms: {
                                 elevationScale: { value: 0.2 },
                                 obliquity: { value: 0.41 },
                                 seed: { value: Math.random() * 1000 },
-                                equatorTemp: { value: equatorTemp }
+                                equatorTemp: { value: equatorTemp },
+                                seaLevel: { value: seaLevel }
                         },
                         vertexShader,
                         fragmentShader,
@@ -20,6 +21,7 @@ uniform float elevationScale;
 uniform float obliquity;
 uniform float seed;
 uniform float equatorTemp;
+uniform float seaLevel;
 
 varying float vElevation;
 varying float vLatitude;
@@ -76,8 +78,8 @@ void main() {
   displaced = rotationY(obliquity) * displaced;
 
   float elevation = max(fbm(displaced * 2.5) * 0.8 - 0.2, 0.0);
-
-  displaced *= 1.0 + elevation * elevationScale;
+  float land = max(elevation - seaLevel, 0.0);
+  displaced *= 1.0 + land * elevationScale;
 
   gl_Position = projectionMatrix * modelViewMatrix * vec4(displaced, 1.0);
   vElevation = elevation;

--- a/src/core/DataTargetRenderer.ts
+++ b/src/core/DataTargetRenderer.ts
@@ -11,10 +11,11 @@ export class DataTargetRenderer {
                 private renderer: THREE.WebGLRenderer,
                 private mesh: THREE.Mesh,
                 private camera: THREE.PerspectiveCamera,
-                equatorTemp: number
+                equatorTemp: number,
+                seaLevel: number
         ) {
                 this.renderTarget = new THREE.WebGLRenderTarget(width, height)
-                this.material = new DataMaterial(equatorTemp)
+                this.material = new DataMaterial(equatorTemp, seaLevel)
         }
 
 	render() {

--- a/src/core/DataTargetRenderer.ts
+++ b/src/core/DataTargetRenderer.ts
@@ -12,10 +12,11 @@ export class DataTargetRenderer {
                 private mesh: THREE.Mesh,
                 private camera: THREE.PerspectiveCamera,
                 equatorTemp: number,
-                seaLevel: number
+                seaLevel: number,
+                seed: number
         ) {
                 this.renderTarget = new THREE.WebGLRenderTarget(width, height)
-                this.material = new DataMaterial(equatorTemp, seaLevel)
+                this.material = new DataMaterial(equatorTemp, seaLevel, seed)
         }
 
 	render() {

--- a/src/core/Planet.ts
+++ b/src/core/Planet.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three'
 import { PlanetGenerator } from './PlanetGenerator'
 import { PlanetMaterial, PlanetMaterialOptions } from './PlanetMaterial'
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 import { PlanetType, PlanetPreset, PlanetPresets } from './planetPresets'
 
 export class Planet {
@@ -96,5 +96,6 @@ export class Planet {
         getMesh() { return this.mesh }
         getGenerator() { return this.generator }
         getEquatorTemp() { return this.preset.equatorTemp }
+        getSeaLevel() { return this.preset.seaLevel }
         getRenderer() { return this.renderer }
 }

--- a/src/core/Planet.ts
+++ b/src/core/Planet.ts
@@ -15,6 +15,7 @@ export class Planet {
         private line: THREE.Line
         private autoRotate = true
         private preset: PlanetPreset
+        private seed: number
 
         constructor(canvas: HTMLCanvasElement, type: PlanetType = 'earth') {
                 this.scene = new THREE.Scene()
@@ -25,8 +26,13 @@ export class Planet {
                 this.renderer.setSize(canvas.clientWidth, canvas.clientHeight)
 
                 this.preset = PlanetPresets[type]
-                this.generator = new PlanetGenerator(Math.random(), type)
-                this.mesh = this.createPlanetMesh({ seaLevel: this.preset.seaLevel, equatorTemp: this.preset.equatorTemp })
+                this.seed = Math.random() * 1000
+                this.generator = new PlanetGenerator(this.seed, type)
+                this.mesh = this.createPlanetMesh({
+                        seaLevel: this.preset.seaLevel,
+                        equatorTemp: this.preset.equatorTemp,
+                        seed: this.seed
+                })
 
                 this.controls = new OrbitControls(this.camera, this.renderer.domElement)
                 this.controls.enableDamping = true
@@ -97,5 +103,6 @@ export class Planet {
         getGenerator() { return this.generator }
         getEquatorTemp() { return this.preset.equatorTemp }
         getSeaLevel() { return this.preset.seaLevel }
+        getSeed() { return this.seed }
         getRenderer() { return this.renderer }
 }

--- a/src/core/PlanetMaterial.ts
+++ b/src/core/PlanetMaterial.ts
@@ -91,7 +91,8 @@ void main() {
   float elevation = fbm(displaced * 2.5);
   elevation = elevation * 0.8 - 0.2; // shift average downward
   elevation = max(elevation, 0.0);  // remove any below-sea "holes"
-  displaced *= 1.0 + elevation * elevationScale;
+  float land = max(elevation - seaLevel, 0.0);
+  displaced *= 1.0 + land * elevationScale;
 
   gl_Position = projectionMatrix * modelViewMatrix * vec4(displaced, 1.0);
 

--- a/src/core/PlanetMaterial.ts
+++ b/src/core/PlanetMaterial.ts
@@ -3,6 +3,7 @@ import * as THREE from 'three'
 export interface PlanetMaterialOptions {
         seaLevel: number
         equatorTemp: number
+        seed: number
 }
 
 export class PlanetMaterial extends THREE.ShaderMaterial {
@@ -12,7 +13,7 @@ export class PlanetMaterial extends THREE.ShaderMaterial {
                                 time: { value: 0 },
                                 elevationScale: { value: 0.2 },
                                 obliquity: { value: 0.41 }, // ~23.5 degrees
-                                seed: { value: Math.random() * 1000 },
+                                seed: { value: options.seed },
                                 seaLevel: { value: options.seaLevel },
                                 equatorTemp: { value: options.equatorTemp }
                         },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
-	"compilerOptions": {
-		"baseUrl": ".",
-		"paths": {
-			"@/*": [
-				"src/*"
-			]
-		}
-	},
+        "compilerOptions": {
+                "baseUrl": ".",
+                "paths": {
+                        "@/*": [
+                                "src/*"
+                        ]
+                },
+                "noEmit": true
+        },
 	"include": [
 		"src"
 	]


### PR DESCRIPTION
## Summary
- keep InfoPanel hover data reactive with storeToRefs
- pass sea level to data materials and flatten ocean geometry
- expose planet sea level for data renderer
- avoid JS emission during builds

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d7589c6348333b7a4d56af10c5f70